### PR TITLE
CI: lint y tests con Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ add-ci-build ]  # para ver correr la CI en tu rama
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+        ports: ['5432:5432']
+        # Espera a que Postgres esté listo
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Lint (flake8)
+        run: flake8 .
+
+      - name: Run unit tests (nose)
+        env:
+          # La app usará este URI para conectarse al Postgres del job
+          DATABASE_URI: postgresql://postgres:postgres@localhost:5432/postgres
+        run: nosetests -v


### PR DESCRIPTION
grega workflow de GitHub Actions que ejecuta flake8 y nosetests con Postgres en CI.
Cubre los criterios: lint + unit tests + badge de estado (se añadirá en el README tras validar).